### PR TITLE
fix: use web app fingerprint for SmartRent API requests

### DIFF
--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -24,5 +24,6 @@ export const API_CLIENT_HEADERS = {
   ...COMMON_HEADERS,
   Accept: 'application/json',
   'Content-Type': 'application/json',
-  'X-AppVersion': `ios-resapp-${APP_VERSION}`,
+  // SmartRent now rejects the legacy mobile app fingerprint from non-mobile clients.
+  'X-AppVersion': `homebridge-resweb-${APP_VERSION}`,
 };


### PR DESCRIPTION
## Summary
- switch the SmartRent API request fingerprint away from the legacy iOS app value
- use a web-style X-AppVersion so resident API requests are no longer blocked

## Verification
- built the plugin locally
- replayed authenticated requests to `/api/v1/units` and `/api/v1/hubs/:id/devices` successfully with the new header