### PR TITLE
ci(release): enable npm trusted publishing (OIDC) with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,16 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm for trusted publishing (OIDC requires npm >= 11.5.1)
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: npm clean-install
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
@@ -33,4 +35,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          NPM_CONFIG_PROVENANCE: 'true'
         run: npm run semantic-release


### PR DESCRIPTION
## Summary

Minimal, **non-breaking** subset of #77 that just fixes npm trusted publishing on the release workflow. Scoped this way so it can ship as a patch and doesn't get blocked behind the bigger tooling modernization (ESM migration, ESLint 10 flat config, TS 6, semantic-release 25 stack bump, etc.) which would be a major bump.

## Changes (only `.github/workflows/release.yml`)

- Bump `actions/checkout` v3 → v5
- Bump `actions/setup-node` v3 → v6
- Add `npm install -g npm@latest` step before publish — OIDC trusted publishing requires npm >= 11.5.1
- Set `NPM_CONFIG_PROVENANCE=true` on the Release step so `semantic-release` publishes with provenance attestations
- Keep existing `id-token: write` permission, `registry-url`, and `npm audit signatures` step as-is

## Why split from #77

#77 also migrates to ESM (`"type": "module"`), TypeScript 6, ESLint 10 (flat config), semantic-release 25, husky 9, commitlint 21, drops `.eslintrc.json`/`.eslintignore`, renames `homebridge-ui/server.js` → `src/ui/server.ts`, etc. That is effectively a major-version bump's worth of churn and should be released independently from the trusted-publishing fix.

## Test plan

CI on this PR. No source code changes, no dependency changes.