### PR TITLE
fix(ci): publish to npm via OIDC instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,12 @@ jobs:
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
       - name: Release
+        id: semantic-release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          NPM_CONFIG_PROVENANCE: 'true'
         run: npm run semantic-release
+      - name: Publish to npm (trusted publishing via OIDC)
+        if: hashFiles('dist/*.tgz') != ''
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+        run: npm publish dist/*.tgz --access public --provenance

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -30,6 +30,7 @@
     [
       "@semantic-release/npm",
       {
+        "npmPublish": false,
         "tarballDir": "dist"
       }
     ],


### PR DESCRIPTION
## Problem

The release workflow fails with:

```
npm ERR! 401 Unauthorized - GET https://registry.npmjs.org/-/whoami
✖  EINVALIDNPMTOKEN Invalid npm token.
```

Even though [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) is configured for this package, `@semantic-release/npm`'s `verifyConditions` step calls `npm whoami`, which requires a classic registry token. There is no `NPM_TOKEN` secret (intentionally — we're using OIDC), so the step 401s and the release aborts.

OIDC trusted publishing is currently only honored by the `npm publish` CLI command itself; `@semantic-release/npm` does not yet support it for the auth-verification step.

## Fix

- Set `npmPublish: false` on the `@semantic-release/npm` plugin. This skips the `whoami` check and the publish call, but still bumps `package.json` and packs the tarball into `dist/`.
- Add a follow-up `npm publish dist/*.tgz --access public --provenance` step in the workflow, guarded by `hashFiles('dist/*.tgz') != ''` so it's a no-op when semantic-release decided not to release. This step uses npm's native OIDC trusted publishing flow (npm >= 11.5.1, already installed earlier in the job) and emits provenance.
- Removed `NPM_CONFIG_PROVENANCE` from the semantic-release step since it no longer publishes; kept on the publish step.

## Notes

- `id-token: write` permission is already granted in the workflow.
- Other semantic-release steps (changelog, GitHub release, git commit-back) are unchanged.