### PR TITLE
ci(release): fix npm publish 401 by using trusted publishing in a dedicated step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,18 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          NPM_CONFIG_PROVENANCE: 'true'
         run: npm run semantic-release
+      - name: Publish to npm with trusted publishing (OIDC)
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+        run: |
+          shopt -s nullglob
+          tarballs=(dist/*.tgz)
+          if [ ${#tarballs[@]} -eq 0 ]; then
+            echo "No tarball produced by semantic-release; skipping npm publish."
+            exit 0
+          fi
+          for tarball in "${tarballs[@]}"; do
+            echo "Publishing $tarball"
+            npm publish "$tarball" --access public --provenance
+          done

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -30,6 +30,7 @@
     [
       "@semantic-release/npm",
       {
+        "npmPublish": false,
         "tarballDir": "dist"
       }
     ],


### PR DESCRIPTION
## Problem

The release workflow on `master` is failing with:

```
npm ERR! 401 Unauthorized - GET https://registry.npmjs.org/-/whoami
[semantic-release] › ✖  Failed step \"verifyConditions\" of plugin \"@semantic-release/npm\"
[semantic-release] › ✖  EINVALIDNPMTOKEN Invalid npm token.
```

`@semantic-release/npm` runs `npm whoami` against the configured registry during its `verifyConditions` step. That request requires a bearer token, so it fails with 401 when no `NPM_TOKEN` is provided — even though npm **trusted publishing (OIDC)** was enabled on the registry side in #78. Trusted publishing only takes effect during `npm publish`; it does not satisfy the `whoami` precheck.

## Fix

Split the responsibilities:

1. **`.releaserc.json`** — set `npmPublish: false` on `@semantic-release/npm`. semantic-release continues to determine the next version, update `package.json` / `package-lock.json`, regenerate the changelog, create the GitHub release, commit, and pack a tarball into `dist/`. It no longer talks to the npm registry, so `NPM_TOKEN` is not required.
2. **`.github/workflows/release.yml`** — add a follow-up \"Publish to npm with trusted publishing (OIDC)\" step that runs `npm publish dist/*.tgz --access public --provenance`. The job already has `id-token: write`, so npm CLI ≥ 11.5.1 negotiates an OIDC token with the registry automatically — no `NPM_TOKEN` secret needed. The step no-ops if semantic-release did not produce a tarball (e.g. no releasable commits).

## Notes

- Trusted publisher must already be configured on npmjs.com for `@bhavishyachandra/homebridge-smartrent` pointing at this repo and the `Release` workflow / job (done in #78).
- `NPM_CONFIG_PROVENANCE` is moved to the publish step where it actually applies.
- No other workflow steps or plugins change.