### PR TITLE
fix(ci): treat dist/*.tgz as a file path when publishing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,17 @@ jobs:
         if: hashFiles('dist/*.tgz') != ''
         env:
           NPM_CONFIG_PROVENANCE: 'true'
-        run: npm publish dist/*.tgz --access public --provenance
+        # Use an explicit ./ prefix on every tarball: `npm publish dist/foo.tgz`
+        # is parsed by npm as a GitHub `owner/repo` shorthand and triggers a
+        # `git ls-remote` against github.com, not a tarball publish.
+        run: |
+          shopt -s nullglob
+          tarballs=(dist/*.tgz)
+          if [ ${#tarballs[@]} -eq 0 ]; then
+            echo "No tarball found in dist/, nothing to publish."
+            exit 0
+          fi
+          for t in "${tarballs[@]}"; do
+            echo "Publishing ./$t"
+            npm publish "./$t" --access public --provenance
+          done


### PR DESCRIPTION
## Problem

After #79 merged, the release workflow on `master` cut version 1.4.3 successfully but the new publish step failed with:

\`\`\`
npm error code 128
npm error An unknown git error occurred
npm error command git --no-replace-objects ls-remote ssh://git@github.com/dist/bhavishyachandra-homebridge-smartrent-1.4.3.tgz.git
npm error git@github.com: Permission denied (publickey).
\`\`\`

When the npm CLI sees a positional argument that looks like \`owner/repo\` (e.g. \`dist/bhavishyachandra-homebridge-smartrent-1.4.3.tgz\`), it parses it as a GitHub shorthand package spec and tries to \`git ls-remote\` it — it does **not** treat it as a local file. That's why the publish never happened.

## Fix

Prefix the tarball path with \`./\` so npm parses it as a file path, e.g. \`npm publish ./dist/foo.tgz\`. Wrapped in a small bash loop with \`shopt -s nullglob\` so the step is a clean no-op when semantic-release didn't produce a tarball (no release).

Only the publish step in [.github/workflows/release.yml](.github/workflows/release.yml) is changed.

## Follow-up note (not in this PR)

\`master\` is currently at \`package.json\` version 1.4.3 (committed back by semantic-release) but **1.4.3 was never published to npm** because of this bug. After this PR merges, no new commit triggers a release-worthy change, so semantic-release will say \"no release\" and the publish step will no-op. To get 1.4.3 onto npm you'll likely want to either publish it manually one-time or land a small \`fix:\` commit to trigger a 1.4.4 release.